### PR TITLE
fix: phone number regex conflict

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@bitcoinerlab/secp256k1": "^1.1.1",
     "bitcoinjs-lib": "^7.0.0-rc.0",
     "bolt11": "~1.4.1",
+    "libphonenumber-js": "^1.12.6",
     "lnurl-pay": "^4.0.0"
   },
   "devDependencies": {
@@ -41,6 +42,7 @@
     "eslint-plugin-import": "^2.27.5",
     "globals": "^15.11.0",
     "jest": "^29.7.0",
+    "libphonenumber-js": "^1.12.6",
     "lnurl-pay": "^4.0.0",
     "prettier": "^3.3.3",
     "ts-jest": "^29.2.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@22.13.13)(ts-node@10.9.2(@types/node@22.13.13)(typescript@5.8.2))
+      libphonenumber-js:
+        specifier: ^1.12.6
+        version: 1.12.6
       lnurl-pay:
         specifier: ^4.0.0
         version: 4.0.0
@@ -1992,6 +1995,9 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  libphonenumber-js@1.12.6:
+    resolution: {integrity: sha512-PJiS4ETaUfCOFLpmtKzAbqZQjCCKVu2OhTV4SVNNE7c2nu/dACvtCqj4L0i/KWNnIgRv7yrILvBj5Lonv5Ncxw==}
 
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
@@ -5139,6 +5145,8 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  libphonenumber-js@1.12.6: {}
 
   lilconfig@3.1.3: {}
 

--- a/src/parsing/index.spec.ts
+++ b/src/parsing/index.spec.ts
@@ -703,7 +703,7 @@ describe("parsePaymentDestination - Phone Number as IntraLedger Payment", () => 
         },
       },
       {
-        description: `validates a phone number without plus simbol as an intraledger payment on ${network}`,
+        description: `validates a phone number without plus symbol as an intraledger payment on ${network}`,
         destination: "50370123456",
         network,
         expected: {

--- a/src/parsing/index.spec.ts
+++ b/src/parsing/index.spec.ts
@@ -694,27 +694,46 @@ describe("parsePaymentDestination - Phone Number as IntraLedger Payment", () => 
     networks.flatMap((network) => [
       {
         description: `validates a phone number as an intraledger payment on ${network}`,
-        destination: "+1234567890",
+        destination: "+50370123456",
         network,
         expected: {
           paymentType: PaymentType.Intraledger,
-          handle: "+1234567890",
+          handle: "+50370123456",
+          valid: true,
+        },
+      },
+      {
+        description: `validates a phone number without plus simbol as an intraledger payment on ${network}`,
+        destination: "50370123456",
+        network,
+        expected: {
+          paymentType: PaymentType.Intraledger,
+          handle: "50370123456",
           valid: true,
         },
       },
       {
         description: `validates a phone number with max length as an intraledger payment on ${network}`,
-        destination: "+12345678901234",
+        destination: "+12025550123",
         network,
         expected: {
           paymentType: PaymentType.Intraledger,
-          handle: "+12345678901234",
+          handle: "+12025550123",
           valid: true,
         },
       },
       {
+        description: `invalidates a phone number without country code or plus symbol on ${network}`,
+        destination: "70123456",
+        network,
+        expected: {
+          paymentType: PaymentType.Unknown,
+          valid: false,
+        },
+      },
+      {
         description: `invalidates a phone number that is too short on ${network}`,
-        destination: "+12345",
+        destination: "+5037012",
         network,
         expected: {
           paymentType: PaymentType.Unknown,
@@ -723,7 +742,16 @@ describe("parsePaymentDestination - Phone Number as IntraLedger Payment", () => 
       },
       {
         description: `invalidates a phone number that is too long on ${network}`,
-        destination: "+12345678901234567",
+        destination: "+50370123456574898",
+        network,
+        expected: {
+          paymentType: PaymentType.Unknown,
+          valid: false,
+        },
+      },
+      {
+        description: `invalidates a phone number with an unassigned country code on ${network}`,
+        destination: "+99912345678",
         network,
         expected: {
           paymentType: PaymentType.Unknown,

--- a/src/parsing/index.ts
+++ b/src/parsing/index.ts
@@ -245,7 +245,7 @@ const isValidPhoneNumber = (input: string): boolean => {
   if (!phone?.country) {
     return false
   }
-  
+
   return phone.isValid()
 }
 

--- a/src/parsing/index.ts
+++ b/src/parsing/index.ts
@@ -221,7 +221,7 @@ export const decodeInvoiceString = (
   return bolt11.decode(invoice, parseBolt11Network(network))
 }
 
-const reUsername = /(?!^(1|3|bc1|lnbc1))^[0-9a-z_]{3,50}$/iu
+const reUsername = /^(?!\d+$)(?!^(1|3|bc1|lnbc1))[0-9a-z_]{3,50}$/iu
 
 // from https://github.com/bitcoin/bips/blob/master/bip-0020.mediawiki#Transfer%20amount/size
 const reAmount = /^(([\d.]+)(X(\d+))?|x([\da-f]*)(\.([\da-f]*))?(X([\da-f]+))?)$/iu

--- a/src/parsing/index.ts
+++ b/src/parsing/index.ts
@@ -242,7 +242,11 @@ const parseAmount = (txt: string): number => {
 const isValidPhoneNumber = (input: string): boolean => {
   const normalized = input.trim().startsWith("+") ? input.trim() : `+${input.trim()}`
   const phone = parsePhoneNumberFromString(normalized)
-  return Boolean(phone?.isValid() && phone?.country)
+  if (!phone?.country) {
+    return false
+  }
+  
+  return phone.isValid()
 }
 
 type ParsePaymentDestinationArgs = {


### PR DESCRIPTION
## Improve phone number and username validation for payment destinations

### Summary

This pull request includes two improvements to the payment destination parsing logic:

- Use `libphonenumber-js` for phone number validation  
  Replaces regex-based validation with `libphonenumber-js` to ensure phone numbers include valid country codes and are properly parsed.

- Fix: Prevent numeric-only strings from being treated as usernames  
  Updates the username regex to reject values that contain only numbers (example: `70123456`), which were previously incorrectly interpreted as intraledger handles.

---

### Why this change?

These changes improve accuracy and user experience when sending payments:

- Users can now input phone numbers without needing to include the `+` symbol (example: `50370123456` is accepted).
- Phone number validation now ensures that only numbers with valid country codes are allowed.
- Avoids conflicts between numeric phone numbers and usernames by applying stricter validation rules.