### PR TITLE
fix: resolve lightning addresses as lnurl behind a flag

### DIFF
--- a/src/parsing/index.spec.ts
+++ b/src/parsing/index.spec.ts
@@ -695,6 +695,255 @@ describe("parsePaymentDestination IntraLedger handles", () => {
   })
 })
 
+describe("parsePaymentDestination with preferLnurlForInternalHandles", () => {
+  const lnAddressDomains = ["blink.sv"]
+
+  it("keeps an internal lightning address as intraledger when the flag is off", () => {
+    const result = parsePaymentDestination({
+      destination: internalLnAddress,
+      network: "mainnet",
+      lnAddressDomains,
+    })
+    expect(result).toEqual(
+      expect.objectContaining({
+        paymentType: PaymentType.Intraledger,
+        handle: "username",
+      }),
+    )
+  })
+
+  it("resolves an internal lightning address as lnurl when the flag is on", () => {
+    const result = parsePaymentDestination({
+      destination: internalLnAddress,
+      network: "mainnet",
+      lnAddressDomains,
+      preferLnurlForInternalHandles: true,
+    })
+    expect(result).toEqual(
+      expect.objectContaining({
+        paymentType: PaymentType.Lnurl,
+        valid: true,
+        lnurl: internalLnAddress,
+        isMerchant: false,
+      }),
+    )
+  })
+
+  it("resolves a lightning address with protocol as lnurl when the flag is on", () => {
+    const result = parsePaymentDestination({
+      destination: `lightning:${internalLnAddress}`,
+      network: "mainnet",
+      lnAddressDomains,
+      preferLnurlForInternalHandles: true,
+    })
+    expect(result).toEqual(
+      expect.objectContaining({
+        paymentType: PaymentType.Lnurl,
+        valid: true,
+        lnurl: internalLnAddress,
+        isMerchant: false,
+      }),
+    )
+  })
+
+  it("resolves a bare username as lnurl by appending the domain when the flag is on", () => {
+    const result = parsePaymentDestination({
+      destination: "username",
+      network: "mainnet",
+      lnAddressDomains,
+      preferLnurlForInternalHandles: true,
+    })
+    expect(result).toEqual(
+      expect.objectContaining({
+        paymentType: PaymentType.Lnurl,
+        valid: true,
+        lnurl: internalLnAddress,
+        isMerchant: false,
+      }),
+    )
+  })
+
+  it("resolves an https url on an internal domain as lnurl when the flag is on", () => {
+    const result = parsePaymentDestination({
+      destination: "https://blink.sv/username",
+      network: "mainnet",
+      lnAddressDomains,
+      preferLnurlForInternalHandles: true,
+    })
+    expect(result).toEqual(
+      expect.objectContaining({
+        paymentType: PaymentType.Lnurl,
+        valid: true,
+        lnurl: internalLnAddress,
+        isMerchant: false,
+      }),
+    )
+  })
+
+  it("resolves an https url on a secondary internal domain using its url hostname when the flag is on", () => {
+    const result = parsePaymentDestination({
+      destination: "https://pay.blink.sv/username",
+      network: "mainnet",
+      lnAddressDomains: ["blink.sv", "pay.blink.sv"],
+      preferLnurlForInternalHandles: true,
+    })
+    expect(result).toEqual(
+      expect.objectContaining({
+        paymentType: PaymentType.Lnurl,
+        valid: true,
+        lnurl: "username@pay.blink.sv",
+        isMerchant: false,
+      }),
+    )
+  })
+
+  it("still resolves an external lightning address as lnurl when the flag is on", () => {
+    const result = parsePaymentDestination({
+      destination: externalLnAddress,
+      network: "mainnet",
+      lnAddressDomains,
+      preferLnurlForInternalHandles: true,
+    })
+    expect(result).toEqual(
+      expect.objectContaining({
+        paymentType: PaymentType.Lnurl,
+        valid: true,
+        lnurl: externalLnAddress,
+        isMerchant: false,
+      }),
+    )
+  })
+
+  it("does not convert an intraledger handle with flag (usd) when the flag is on", () => {
+    const result = parsePaymentDestination({
+      destination: "username+usd",
+      network: "mainnet",
+      lnAddressDomains,
+      preferLnurlForInternalHandles: true,
+    })
+    expect(result).toEqual(
+      expect.objectContaining({
+        paymentType: PaymentType.IntraledgerWithFlag,
+        handle: "username",
+        flag: "usd",
+      }),
+    )
+  })
+
+  it("does not convert a lightning address with flag (usd) when the flag is on", () => {
+    const result = parsePaymentDestination({
+      destination: "username+usd@blink.sv",
+      network: "mainnet",
+      lnAddressDomains,
+      preferLnurlForInternalHandles: true,
+    })
+    expect(result).toEqual(
+      expect.objectContaining({
+        paymentType: PaymentType.IntraledgerWithFlag,
+        handle: "username",
+        flag: "usd",
+      }),
+    )
+  })
+
+  it("does not convert a purely numeric internal lightning address when the flag is on", () => {
+    const result = parsePaymentDestination({
+      destination: "254793673300@blink.sv",
+      network: "mainnet",
+      lnAddressDomains,
+      preferLnurlForInternalHandles: true,
+    })
+    expect(result).toEqual(
+      expect.objectContaining({
+        paymentType: PaymentType.Unknown,
+        valid: false,
+      }),
+    )
+  })
+
+  it("resolves a lightning address on a secondary internal domain using its typed domain when the flag is on", () => {
+    const result = parsePaymentDestination({
+      destination: "username@pay.blink.sv",
+      network: "mainnet",
+      lnAddressDomains: ["blink.sv", "pay.blink.sv"],
+      preferLnurlForInternalHandles: true,
+    })
+    expect(result).toEqual(
+      expect.objectContaining({
+        paymentType: PaymentType.Lnurl,
+        valid: true,
+        lnurl: "username@pay.blink.sv",
+        isMerchant: false,
+      }),
+    )
+  })
+
+  it("appends the primary domain to a bare username when several are configured", () => {
+    const result = parsePaymentDestination({
+      destination: "username",
+      network: "mainnet",
+      lnAddressDomains: ["blink.sv", "pay.blink.sv"],
+      preferLnurlForInternalHandles: true,
+    })
+    expect(result).toEqual(
+      expect.objectContaining({
+        paymentType: PaymentType.Lnurl,
+        valid: true,
+        lnurl: "username@blink.sv",
+        isMerchant: false,
+      }),
+    )
+  })
+
+  it("keeps an http handle on a non-internal domain as WrongDomain when the flag is on", () => {
+    const result = parsePaymentDestination({
+      destination: "https://some.where/username",
+      network: "mainnet",
+      lnAddressDomains,
+      preferLnurlForInternalHandles: true,
+    })
+    expect(result).toEqual(
+      expect.objectContaining({
+        valid: false,
+        paymentType: PaymentType.Intraledger,
+        invalidReason: InvalidIntraledgerReason.WrongDomain,
+      }),
+    )
+  })
+
+  it("keeps a bare username as intraledger when there is no domain to append", () => {
+    const result = parsePaymentDestination({
+      destination: "username",
+      network: "mainnet",
+      lnAddressDomains: [],
+      preferLnurlForInternalHandles: true,
+    })
+    expect(result).toEqual(
+      expect.objectContaining({
+        paymentType: PaymentType.Intraledger,
+        handle: "username",
+      }),
+    )
+  })
+
+  it("ignores the flag for phone numbers and still resolves them as a phone lnurl", () => {
+    const result = parsePaymentDestination({
+      destination: "+50370123456",
+      network: "mainnet",
+      lnAddressDomains,
+      preferLnurlForInternalHandles: true,
+    })
+    expect(result).toEqual(
+      expect.objectContaining({
+        paymentType: PaymentType.Lnurl,
+        valid: true,
+        lnurl: `+50370123456@${lnAddressDomains[0]}`,
+        isMerchant: false,
+      }),
+    )
+  })
+})
+
 describe("parsePaymentDestination - Phone Number as LNURL Payment", () => {
   const networks: Network[] = ["mainnet", "signet", "regtest"]
   const lnAddressDomains = ["blink.sv"]

--- a/src/parsing/index.ts
+++ b/src/parsing/index.ts
@@ -259,6 +259,7 @@ type ParsePaymentDestinationArgs = {
   lnAddressDomains: string[]
   inputSource?: InputSource
   displayCurrency?: string
+  preferLnurlForInternalHandles?: boolean
 }
 
 const getLNParam = (data: string): string | null => {
@@ -375,30 +376,46 @@ const getIntraLedgerPayResponse = ({
   destinationWithoutProtocol,
   destination,
   lnAddressDomains,
+  preferLnurlForInternalHandles = false,
 }: {
   destinationWithoutProtocol: string
   destination: string
   lnAddressDomains: string[]
-}): IntraledgerPaymentDestination | UnknownPaymentDestination => {
-  const handle = destinationWithoutProtocol.match(/^(http|\/\/)/iu)
+  preferLnurlForInternalHandles?: boolean
+}):
+  | IntraledgerPaymentDestination
+  | LnurlPaymentDestination
+  | UnknownPaymentDestination => {
+  const isHttpHandle = Boolean(destinationWithoutProtocol.match(/^(http|\/\/)/iu))
+  const handle = isHttpHandle
     ? destinationWithoutProtocol.split("/")[
         destinationWithoutProtocol.split("/").length - 1
       ]
     : destinationWithoutProtocol
 
-  if (destinationWithoutProtocol.match(/^(http|\/\/)/iu)) {
-    const domain = new URL(destination).hostname
-    if (!lnAddressDomains.find((lnAddressDomain) => lnAddressDomain === domain)) {
-      return {
-        valid: false,
-        paymentType: PaymentType.Intraledger,
-        handle,
-        invalidReason: InvalidIntraledgerReason.WrongDomain,
-      }
+  const domain = isHttpHandle ? new URL(destination).hostname : lnAddressDomains[0]
+
+  if (
+    isHttpHandle &&
+    !lnAddressDomains.find((lnAddressDomain) => lnAddressDomain === domain)
+  ) {
+    return {
+      valid: false,
+      paymentType: PaymentType.Intraledger,
+      handle,
+      invalidReason: InvalidIntraledgerReason.WrongDomain,
     }
   }
 
   if (handle?.match(reUsername)) {
+    if (preferLnurlForInternalHandles && domain) {
+      return {
+        valid: true,
+        paymentType: PaymentType.Lnurl,
+        lnurl: `${handle}@${domain}`,
+        isMerchant: false,
+      }
+    }
     return {
       valid: true,
       paymentType: PaymentType.Intraledger,
@@ -433,12 +450,14 @@ const getLNURLPayResponse = ({
   network,
   inputSource = "manual",
   displayCurrency,
+  preferLnurlForInternalHandles = false,
 }: {
   lnAddressDomains: string[]
   destination: string
   network: Network
   inputSource?: InputSource
   displayCurrency?: string
+  preferLnurlForInternalHandles?: boolean
 }):
   | LnurlPaymentDestination
   | IntraledgerPaymentDestination
@@ -449,7 +468,13 @@ const getLNURLPayResponse = ({
   if (lnAddress) {
     const { username, domain } = lnAddress
 
-    if (lnAddressDomains.find((lnAddressDomain) => lnAddressDomain === domain)) {
+    const resolveAsLnurl =
+      preferLnurlForInternalHandles && Boolean(username.match(reUsername))
+
+    if (
+      !resolveAsLnurl &&
+      lnAddressDomains.find((lnAddressDomain) => lnAddressDomain === domain)
+    ) {
       return getIntraLedgerPayResponse({
         destinationWithoutProtocol: username,
         lnAddressDomains,
@@ -681,6 +706,7 @@ export const parsePaymentDestination = ({
   lnAddressDomains,
   inputSource = "manual",
   displayCurrency,
+  preferLnurlForInternalHandles = false,
 }: ParsePaymentDestinationArgs): ParsedPaymentDestination => {
   if (!destination) {
     return { paymentType: PaymentType.NullInput }
@@ -702,6 +728,7 @@ export const parsePaymentDestination = ({
         network,
         inputSource,
         displayCurrency,
+        preferLnurlForInternalHandles,
       })
     case PaymentType.Lightning:
       return getLightningPayResponse({ destination, network })
@@ -713,6 +740,7 @@ export const parsePaymentDestination = ({
         destinationWithoutProtocol,
         destination,
         lnAddressDomains,
+        preferLnurlForInternalHandles,
       })
     case PaymentType.Unified:
       return getUnifiedPayResponse({


### PR DESCRIPTION
Adds a `resolveLnAddressAsLnurl` flag (default `false`) to `parsePaymentDestination`.

With it on, Blink lightning addresses resolve as `Lnurl` instead of intraledger, and the domain is added when only the username is given. We need this so a custodial account can pay a self-custodial recipient over LNURL, since that username has no custodial account. Part of blinkbitcoin/blink-wip#879.

It leaves `+usd` handles, numeric usernames, wrong-domain links and phone numbers as they were, and the default keeps the current behavior so existing callers aren't affected.

Tests cover the different address forms and the flag-off case
