### PR TITLE
feat!: return merchant choices for payment inputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ yarn-error.log
 .vscode/
 .DS_Store
 .direnv/
+.codebase-memory/
+.planning/

--- a/README.md
+++ b/README.md
@@ -23,6 +23,22 @@ const { valid, paymentType, amount } = parsePaymentDestination({
 })
 ```
 
+When a QR code matches one merchant payment integration, the result remains a valid
+`PaymentType.Lnurl` and includes `isMerchant: true` plus a `merchant` object. When a
+QR code matches multiple integrations that cannot be uniquely selected by
+`displayCurrency`, the result is:
+
+```ts
+{
+  paymentType: PaymentType.Merchant,
+  merchants: Merchant[],
+}
+```
+
+Each merchant includes its ID, Lightning address, category, display metadata, and an
+optional display currency. `category` is metadata only; consumers make all selection,
+filtering, regional eligibility, and policy decisions.
+
 ## Test
 
 Test with Jest framework:

--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ Each merchant includes its ID, Lightning address, category, display metadata, an
 optional display currency. `category` is metadata only; consumers make all selection,
 filtering, regional eligibility, and policy decisions.
 
+`PaymentType.Merchant` requires consumer selection before payment and does not include a
+`valid` field. Branch on `paymentType` before relying on `valid` or initiating payment.
+
 ## Test
 
 Test with Jest framework:

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ const { valid, paymentType, amount } = parsePaymentDestination({
 })
 ```
 
-When a QR code matches one merchant payment integration, the result remains a valid
-`PaymentType.Lnurl` and includes `isMerchant: true` plus a `merchant` object. When a
-QR code matches multiple integrations that cannot be uniquely selected by
-`displayCurrency`, the result is:
+When a QR code or non-phone manual input matches one merchant payment integration, the
+result remains a valid `PaymentType.Lnurl` and includes `isMerchant: true` plus a
+`merchant` object. When the input matches multiple integrations that cannot be uniquely
+selected by `displayCurrency`, the result is:
 
 ```ts
 {

--- a/src/parsing/index.spec.ts
+++ b/src/parsing/index.spec.ts
@@ -1394,6 +1394,22 @@ describe("parsePaymentDestination QR Input with Merchant Priority", () => {
     })
   })
 
+  it("keeps a QR Lightning Address on a merchant domain as LNURL", () => {
+    expect(
+      parsePaymentDestination({
+        destination: "alice@snapscan.com",
+        network: "mainnet",
+        lnAddressDomains: ["blink.sv"],
+        inputSource: "qr",
+      }),
+    ).toEqual({
+      paymentType: PaymentType.Lnurl,
+      valid: true,
+      lnurl: "alice@snapscan.com",
+      isMerchant: false,
+    })
+  })
+
   it("normalizes a lightning-prefixed manual merchant URL before matching", () => {
     expect(
       parsePaymentDestination({

--- a/src/parsing/index.spec.ts
+++ b/src/parsing/index.spec.ts
@@ -103,6 +103,7 @@ describe("parsePaymentDestination validations", () => {
         isMerchant: false,
       }),
     )
+    expect(result).not.toHaveProperty("merchant")
   })
 
   it("validates an lnurlw destination", () => {
@@ -1082,6 +1083,11 @@ describe("parsePaymentDestination Merchant QR", () => {
         lnurl:
           "00020129530023za.co.electrum.picknpay0122RD2HAK3KTI53EC%2Fconfirm520458125303710540115802ZA5916cryptoqrtestscan6002CT63049BE2@cryptoqr.net",
         isMerchant: true,
+        merchant: expect.objectContaining({
+          id: "picknpay",
+          category: "merchant-payment",
+          companyName: "Money Badger",
+        }),
       }),
     )
   })
@@ -1101,6 +1107,7 @@ describe("parsePaymentDestination Merchant QR", () => {
         valid: true,
         lnurl: "https%3A%2F%2Fpos.snapscan.io%2Fqr%2FSTB2ACC8@cryptoqr.net",
         isMerchant: true,
+        merchant: expect.objectContaining({ id: "snapscan" }),
       }),
     )
   })
@@ -1122,6 +1129,29 @@ describe("parsePaymentDestination Merchant QR", () => {
         lnurl:
           "00020129530023za.co.electrum.picknpay0122RD2HAK3KTI53EC%2Fconfirm520458125303710540115802ZA5916cryptoqrtestscan6002CT63049BE2@staging.cryptoqr.net",
         isMerchant: true,
+        merchant: expect.objectContaining({ id: "picknpay" }),
+      }),
+    )
+  })
+
+  it("validates a merchant QR code on regtest", () => {
+    const merchantQR =
+      "00020129530023za.co.electrum.picknpay0122RD2HAK3KTI53EC/confirm520458125303710540115802ZA5916cryptoqrtestscan6002CT63049BE2"
+
+    expect(
+      parsePaymentDestination({
+        destination: merchantQR,
+        network: "regtest",
+        lnAddressDomains: ["blink.sv"],
+      }),
+    ).toEqual(
+      expect.objectContaining({
+        paymentType: PaymentType.Lnurl,
+        valid: true,
+        lnurl:
+          "00020129530023za.co.electrum.picknpay0122RD2HAK3KTI53EC%2Fconfirm520458125303710540115802ZA5916cryptoqrtestscan6002CT63049BE2@staging.cryptoqr.net",
+        isMerchant: true,
+        merchant: expect.objectContaining({ id: "picknpay" }),
       }),
     )
   })
@@ -1142,6 +1172,7 @@ describe("parsePaymentDestination - Numeric Lightning Addresses", () => {
         isMerchant: false,
       }),
     )
+    expect(result).not.toHaveProperty("merchant")
   })
 
   it("validates an external lightning address with phone number username (with +)", () => {
@@ -1225,7 +1256,30 @@ describe("parsePaymentDestination - Numeric Lightning Addresses", () => {
 
 describe("parsePaymentDestination QR Input with Merchant Priority", () => {
   const phoneNumber = "+27123456789"
-  const mockMerchantLnurl = "merchant-identifier@cryptoqr.net"
+  const mockMerchant = {
+    id: "test-merchant",
+    lnurl: "merchant-identifier@cryptoqr.net",
+    category: "merchant-payment" as const,
+    title: "Test Merchant",
+    description: "",
+    companyName: "Money Badger",
+    termsUrl: "https://www.moneybadger.co.za/deals/terms-and-conditions",
+  }
+
+  const currencyMerchants = [
+    {
+      ...mockMerchant,
+      id: "cop-merchant",
+      lnurl: "merchant-cop@cryptoqr.net",
+      displayCurrency: "COP",
+    },
+    {
+      ...mockMerchant,
+      id: "zar-merchant",
+      lnurl: "merchant-zar@cryptoqr.net",
+      displayCurrency: "ZAR",
+    },
+  ]
 
   afterEach(() => {
     jest.restoreAllMocks()
@@ -1233,8 +1287,8 @@ describe("parsePaymentDestination QR Input with Merchant Priority", () => {
 
   it("prioritizes merchant when QR input matches both phone and merchant pattern", () => {
     const merchantSpy = jest
-      .spyOn(merchants, "convertMerchantQRToLightningAddress")
-      .mockReturnValue(mockMerchantLnurl)
+      .spyOn(merchants, "getMatchingMerchants")
+      .mockReturnValue([mockMerchant])
 
     const paymentDestination = parsePaymentDestination({
       destination: phoneNumber,
@@ -1251,16 +1305,15 @@ describe("parsePaymentDestination QR Input with Merchant Priority", () => {
       expect.objectContaining({
         paymentType: PaymentType.Lnurl,
         valid: true,
-        lnurl: mockMerchantLnurl,
+        lnurl: mockMerchant.lnurl,
         isMerchant: true,
+        merchant: mockMerchant,
       }),
     )
   })
 
   it("returns phone LNURL when QR input is phone without merchant match", () => {
-    const merchantSpy = jest
-      .spyOn(merchants, "convertMerchantQRToLightningAddress")
-      .mockReturnValue(null)
+    const merchantSpy = jest.spyOn(merchants, "getMatchingMerchants").mockReturnValue([])
 
     const paymentDestination = parsePaymentDestination({
       destination: phoneNumber,
@@ -1281,10 +1334,11 @@ describe("parsePaymentDestination QR Input with Merchant Priority", () => {
         isMerchant: false,
       }),
     )
+    expect(paymentDestination).not.toHaveProperty("merchant")
   })
 
   it("returns phone LNURL when manual input is phone (does not check merchant)", () => {
-    const merchantSpy = jest.spyOn(merchants, "convertMerchantQRToLightningAddress")
+    const merchantSpy = jest.spyOn(merchants, "getMatchingMerchants")
 
     const paymentDestination = parsePaymentDestination({
       destination: phoneNumber,
@@ -1305,7 +1359,7 @@ describe("parsePaymentDestination QR Input with Merchant Priority", () => {
   })
 
   it("returns phone LNURL when inputSource is undefined (defaults to manual)", () => {
-    const merchantSpy = jest.spyOn(merchants, "convertMerchantQRToLightningAddress")
+    const merchantSpy = jest.spyOn(merchants, "getMatchingMerchants")
 
     const paymentDestination = parsePaymentDestination({
       destination: phoneNumber,
@@ -1322,5 +1376,103 @@ describe("parsePaymentDestination QR Input with Merchant Priority", () => {
         isMerchant: false,
       }),
     )
+  })
+
+  it("returns all matching merchants when a QR match is ambiguous", () => {
+    jest.spyOn(merchants, "getMatchingMerchants").mockReturnValue(currencyMerchants)
+
+    expect(
+      parsePaymentDestination({
+        destination: "ambiguous-merchant-qr",
+        network: "mainnet",
+        lnAddressDomains: ["blink.sv"],
+        inputSource: "qr",
+      }),
+    ).toEqual({ paymentType: PaymentType.Merchant, merchants: currencyMerchants })
+  })
+
+  it("uses displayCurrency when exactly one QR merchant matches it", () => {
+    jest.spyOn(merchants, "getMatchingMerchants").mockReturnValue(currencyMerchants)
+
+    expect(
+      parsePaymentDestination({
+        destination: "ambiguous-merchant-qr",
+        network: "mainnet",
+        lnAddressDomains: ["blink.sv"],
+        inputSource: "qr",
+        displayCurrency: " zar ",
+      }),
+    ).toEqual({
+      paymentType: PaymentType.Lnurl,
+      valid: true,
+      lnurl: "merchant-zar@cryptoqr.net",
+      isMerchant: true,
+      merchant: currencyMerchants[1],
+    })
+  })
+
+  it("keeps QR merchants ambiguous when no currency matches", () => {
+    jest.spyOn(merchants, "getMatchingMerchants").mockReturnValue(currencyMerchants)
+
+    expect(
+      parsePaymentDestination({
+        destination: "ambiguous-merchant-qr",
+        network: "mainnet",
+        lnAddressDomains: ["blink.sv"],
+        inputSource: "qr",
+        displayCurrency: "EUR",
+      }),
+    ).toEqual({ paymentType: PaymentType.Merchant, merchants: currencyMerchants })
+  })
+
+  it("keeps same-currency QR merchants ambiguous", () => {
+    const sameCurrencyMerchants = currencyMerchants.map((merchant) => ({
+      ...merchant,
+      displayCurrency: "ZAR",
+    }))
+    jest.spyOn(merchants, "getMatchingMerchants").mockReturnValue(sameCurrencyMerchants)
+
+    expect(
+      parsePaymentDestination({
+        destination: "ambiguous-merchant-qr",
+        network: "mainnet",
+        lnAddressDomains: ["blink.sv"],
+        inputSource: "qr",
+        displayCurrency: "ZAR",
+      }),
+    ).toEqual({ paymentType: PaymentType.Merchant, merchants: sameCurrencyMerchants })
+  })
+
+  it("returns all matching merchants for ambiguous manual input", () => {
+    jest.spyOn(merchants, "getMatchingMerchants").mockReturnValue(currencyMerchants)
+
+    expect(
+      parsePaymentDestination({
+        destination: "ambiguous-merchant-input",
+        network: "mainnet",
+        lnAddressDomains: ["blink.sv"],
+        inputSource: "manual",
+      }),
+    ).toEqual({ paymentType: PaymentType.Merchant, merchants: currencyMerchants })
+  })
+
+  it("uses displayCurrency to resolve ambiguous manual input", () => {
+    jest.spyOn(merchants, "getMatchingMerchants").mockReturnValue(currencyMerchants)
+
+    expect(
+      parsePaymentDestination({
+        destination: "ambiguous-merchant-input",
+        network: "mainnet",
+        lnAddressDomains: ["blink.sv"],
+        inputSource: "manual",
+        displayCurrency: "ZAR",
+      }),
+    ).toEqual({
+      paymentType: PaymentType.Lnurl,
+      valid: true,
+      lnurl: "merchant-zar@cryptoqr.net",
+      isMerchant: true,
+      merchant: currencyMerchants[1],
+    })
   })
 })

--- a/src/parsing/index.spec.ts
+++ b/src/parsing/index.spec.ts
@@ -1378,6 +1378,60 @@ describe("parsePaymentDestination QR Input with Merchant Priority", () => {
     )
   })
 
+  it("keeps an external Lightning Address on a merchant domain as LNURL", () => {
+    expect(
+      parsePaymentDestination({
+        destination: "alice@snapscan.com",
+        network: "mainnet",
+        lnAddressDomains: ["blink.sv"],
+        inputSource: "manual",
+      }),
+    ).toEqual({
+      paymentType: PaymentType.Lnurl,
+      valid: true,
+      lnurl: "alice@snapscan.com",
+      isMerchant: false,
+    })
+  })
+
+  it("normalizes a lightning-prefixed manual merchant URL before matching", () => {
+    expect(
+      parsePaymentDestination({
+        destination: "lightning:https://pos.snapscan.io/qr/STB2ACC8",
+        network: "mainnet",
+        lnAddressDomains: ["blink.sv"],
+        inputSource: "manual",
+      }),
+    ).toEqual(
+      expect.objectContaining({
+        paymentType: PaymentType.Lnurl,
+        valid: true,
+        lnurl: "https%3A%2F%2Fpos.snapscan.io%2Fqr%2FSTB2ACC8@cryptoqr.net",
+        isMerchant: true,
+        merchant: expect.objectContaining({ id: "snapscan" }),
+      }),
+    )
+  })
+
+  it("trims QR merchant content before matching", () => {
+    expect(
+      parsePaymentDestination({
+        destination: " 8784599487 ",
+        network: "mainnet",
+        lnAddressDomains: ["blink.sv"],
+        inputSource: "qr",
+      }),
+    ).toEqual(
+      expect.objectContaining({
+        paymentType: PaymentType.Lnurl,
+        valid: true,
+        lnurl: "8784599487@cryptoqr.net",
+        isMerchant: true,
+        merchant: expect.objectContaining({ id: "scantopay-10-digits" }),
+      }),
+    )
+  })
+
   it("returns all matching merchants when a QR match is ambiguous", () => {
     jest.spyOn(merchants, "getMatchingMerchants").mockReturnValue(currencyMerchants)
 

--- a/src/parsing/index.ts
+++ b/src/parsing/index.ts
@@ -712,12 +712,13 @@ export const parsePaymentDestination = ({
     rawDestination: destination,
   })
 
-  if (
-    inputSource === "qr" ||
+  const isMerchantCandidate =
     paymentType === PaymentType.Intraledger ||
     paymentType === PaymentType.IntraledgerWithFlag ||
-    paymentType === PaymentType.Unknown
-  ) {
+    paymentType === PaymentType.Unknown ||
+    (inputSource === "qr" && isValidPhoneNumber(destinationWithoutProtocol))
+
+  if (isMerchantCandidate) {
     const merchants = getMatchingMerchants({ qrContent: merchantContent, network })
     const merchantResponse = getMerchantLnurlPaymentDestination({
       merchants,

--- a/src/parsing/index.ts
+++ b/src/parsing/index.ts
@@ -117,6 +117,11 @@ export type LnurlPaymentDestination =
       lnurl: string
       isMerchant: false
     }
+  | {
+      paymentType: typeof PaymentType.Lnurl
+      valid: false
+      invalidReason: InvalidLnurlPaymentDestinationReason
+    }
 
 type MerchantLnurlPaymentDestination = {
   paymentType: typeof PaymentType.Lnurl
@@ -126,16 +131,10 @@ type MerchantLnurlPaymentDestination = {
   merchant: Merchant
 }
 
-export type MerchantPaymentDestination =
-  | {
-      paymentType: typeof PaymentType.Merchant
-      merchants: Merchant[]
-    }
-  | {
-      paymentType: typeof PaymentType.Lnurl
-      valid: false
-      invalidReason: InvalidLnurlPaymentDestinationReason
-    }
+export type MerchantPaymentDestination = {
+  paymentType: typeof PaymentType.Merchant
+  merchants: Merchant[]
+}
 
 export const InvalidLightningDestinationReason = {
   InvoiceExpired: "InvoiceExpired",

--- a/src/parsing/index.ts
+++ b/src/parsing/index.ts
@@ -479,16 +479,10 @@ const getMerchantLnurlPaymentDestination = ({
 const getLNURLPayResponse = ({
   lnAddressDomains,
   destination,
-  network,
-  inputSource = "manual",
-  displayCurrency,
   preferLnurlForInternalHandles = false,
 }: {
   lnAddressDomains: string[]
   destination: string
-  network: Network
-  inputSource?: InputSource
-  displayCurrency?: string
   preferLnurlForInternalHandles?: boolean
 }):
   | LnurlPaymentDestination
@@ -503,10 +497,7 @@ const getLNURLPayResponse = ({
     const resolveAsLnurl =
       preferLnurlForInternalHandles && Boolean(username.match(reUsername))
 
-    if (
-      !resolveAsLnurl &&
-      lnAddressDomains.find((lnAddressDomain) => lnAddressDomain === domain)
-    ) {
+    if (!resolveAsLnurl && lnAddressDomains.includes(domain)) {
       return getIntraLedgerPayResponse({
         destinationWithoutProtocol: username,
         lnAddressDomains,
@@ -523,16 +514,6 @@ const getLNURLPayResponse = ({
   }
 
   if (isValidPhoneNumber(trimmed)) {
-    if (inputSource === "qr") {
-      const merchantResponse = getMerchantLnurlPaymentDestination({
-        merchants: getMatchingMerchants({ qrContent: trimmed, network }),
-        displayCurrency,
-      })
-      if (merchantResponse) {
-        return merchantResponse
-      }
-    }
-
     const domain = lnAddressDomains[0]
     return {
       valid: true,
@@ -542,10 +523,7 @@ const getLNURLPayResponse = ({
     }
   }
 
-  if (
-    destination.slice(0, 9) === "lnurlw://" ||
-    destination.slice(0, 9) === "lnurlp://"
-  ) {
+  if (destination.startsWith("lnurlw://") || destination.startsWith("lnurlp://")) {
     return {
       valid: true,
       paymentType: PaymentType.Lnurl,
@@ -563,14 +541,6 @@ const getLNURLPayResponse = ({
       lnurl,
       isMerchant: false,
     }
-  }
-
-  const merchantResponse = getMerchantLnurlPaymentDestination({
-    merchants: getMatchingMerchants({ qrContent: destination, network }),
-    displayCurrency,
-  })
-  if (merchantResponse) {
-    return merchantResponse
   }
 
   return {
@@ -733,9 +703,22 @@ export const parsePaymentDestination = ({
   }
 
   const { protocol, destinationWithoutProtocol } = getProtocolAndData(destination)
+  const destinationForParsing =
+    protocol === "lightning" ? destinationWithoutProtocol : destination
+  const merchantContent = destinationForParsing.trim()
+  const paymentType = getPaymentType({
+    protocol,
+    destinationWithoutProtocol,
+    rawDestination: destination,
+  })
 
-  if (inputSource === "qr" || !isValidPhoneNumber(destinationWithoutProtocol)) {
-    const merchants = getMatchingMerchants({ qrContent: destination, network })
+  if (
+    inputSource === "qr" ||
+    paymentType === PaymentType.Intraledger ||
+    paymentType === PaymentType.IntraledgerWithFlag ||
+    paymentType === PaymentType.Unknown
+  ) {
+    const merchants = getMatchingMerchants({ qrContent: merchantContent, network })
     const merchantResponse = getMerchantLnurlPaymentDestination({
       merchants,
       displayCurrency,
@@ -748,19 +731,11 @@ export const parsePaymentDestination = ({
     }
   }
 
-  const paymentType = getPaymentType({
-    protocol,
-    destinationWithoutProtocol,
-    rawDestination: destination,
-  })
   switch (paymentType) {
     case PaymentType.Lnurl:
       return getLNURLPayResponse({
         lnAddressDomains,
-        destination: protocol === "lightning" ? destinationWithoutProtocol : destination,
-        network,
-        inputSource,
-        displayCurrency,
+        destination: destinationForParsing,
         preferLnurlForInternalHandles,
       })
     case PaymentType.Lightning:

--- a/src/parsing/index.ts
+++ b/src/parsing/index.ts
@@ -6,7 +6,11 @@ import * as bitcoinjs from "bitcoinjs-lib"
 import * as ecc from "@bitcoinerlab/secp256k1"
 
 import type { Network, InputSource } from "./types"
-import { convertMerchantQRToLightningAddress } from "./merchants"
+import {
+  getCurrencyMatchedMerchant,
+  getMatchingMerchants,
+  type Merchant,
+} from "./merchants"
 
 bitcoinjs.initEccLib(ecc)
 
@@ -81,6 +85,7 @@ export const PaymentType = {
   IntraledgerWithFlag: "intraledgerWithFlag",
   Onchain: "onchain",
   Lnurl: "lnurl",
+  Merchant: "merchant",
   NullInput: "nullInput",
   Unified: "unified",
   Unknown: "unknown",
@@ -105,11 +110,26 @@ export type InvalidLnurlPaymentDestinationReason =
   (typeof InvalidLnurlPaymentDestinationReason)[keyof typeof InvalidLnurlPaymentDestinationReason]
 
 export type LnurlPaymentDestination =
+  | MerchantLnurlPaymentDestination
   | {
       paymentType: typeof PaymentType.Lnurl
       valid: true
       lnurl: string
-      isMerchant: boolean
+      isMerchant: false
+    }
+
+type MerchantLnurlPaymentDestination = {
+  paymentType: typeof PaymentType.Lnurl
+  valid: true
+  lnurl: string
+  isMerchant: true
+  merchant: Merchant
+}
+
+export type MerchantPaymentDestination =
+  | {
+      paymentType: typeof PaymentType.Merchant
+      merchants: Merchant[]
     }
   | {
       paymentType: typeof PaymentType.Lnurl
@@ -199,6 +219,7 @@ export type ParsedPaymentDestination =
   | UnknownPaymentDestination
   | NullInputPaymentDestination
   | LnurlPaymentDestination
+  | MerchantPaymentDestination
   | LightningPaymentDestination
   | OnchainPaymentDestination
   | IntraledgerPaymentDestination
@@ -297,12 +318,10 @@ const getPaymentType = ({
   protocol,
   destinationWithoutProtocol,
   rawDestination,
-  network,
 }: {
   protocol: string
   destinationWithoutProtocol: string
   rawDestination: string
-  network: Network
 }): PaymentType => {
   // As far as the client is concerned, lnurl is the same as lightning address
   if (
@@ -337,14 +356,6 @@ const getPaymentType = ({
   }
 
   if (isValidPhoneNumber(destinationWithoutProtocol)) {
-    return PaymentType.Lnurl
-  }
-
-  const merchantLightningAddress = convertMerchantQRToLightningAddress({
-    qrContent: rawDestination,
-    network,
-  })
-  if (merchantLightningAddress) {
     return PaymentType.Lnurl
   }
 
@@ -444,6 +455,28 @@ const getIntraLedgerPayResponse = ({
   }
 }
 
+const getMerchantLnurlPaymentDestination = ({
+  merchants,
+  displayCurrency,
+}: {
+  merchants: Merchant[]
+  displayCurrency?: string
+}): MerchantLnurlPaymentDestination | null => {
+  const merchant = getCurrencyMatchedMerchant({ merchants, displayCurrency })
+
+  if (!merchant) {
+    return null
+  }
+
+  return {
+    paymentType: PaymentType.Lnurl,
+    valid: true,
+    lnurl: merchant.lnurl,
+    isMerchant: true,
+    merchant,
+  }
+}
+
 const getLNURLPayResponse = ({
   lnAddressDomains,
   destination,
@@ -492,18 +525,12 @@ const getLNURLPayResponse = ({
 
   if (isValidPhoneNumber(trimmed)) {
     if (inputSource === "qr") {
-      const merchantLightningAddress = convertMerchantQRToLightningAddress({
-        qrContent: trimmed,
-        network,
+      const merchantResponse = getMerchantLnurlPaymentDestination({
+        merchants: getMatchingMerchants({ qrContent: trimmed, network }),
         displayCurrency,
       })
-      if (merchantLightningAddress) {
-        return {
-          valid: true,
-          paymentType: PaymentType.Lnurl,
-          lnurl: merchantLightningAddress,
-          isMerchant: true,
-        }
+      if (merchantResponse) {
+        return merchantResponse
       }
     }
 
@@ -539,18 +566,12 @@ const getLNURLPayResponse = ({
     }
   }
 
-  const merchantLightningAddress = convertMerchantQRToLightningAddress({
-    qrContent: destination,
-    network,
+  const merchantResponse = getMerchantLnurlPaymentDestination({
+    merchants: getMatchingMerchants({ qrContent: destination, network }),
     displayCurrency,
   })
-  if (merchantLightningAddress) {
-    return {
-      valid: true,
-      paymentType: PaymentType.Lnurl,
-      lnurl: merchantLightningAddress,
-      isMerchant: true,
-    }
+  if (merchantResponse) {
+    return merchantResponse
   }
 
   return {
@@ -714,11 +735,24 @@ export const parsePaymentDestination = ({
 
   const { protocol, destinationWithoutProtocol } = getProtocolAndData(destination)
 
+  if (inputSource === "qr" || !isValidPhoneNumber(destinationWithoutProtocol)) {
+    const merchants = getMatchingMerchants({ qrContent: destination, network })
+    const merchantResponse = getMerchantLnurlPaymentDestination({
+      merchants,
+      displayCurrency,
+    })
+    if (merchantResponse) {
+      return merchantResponse
+    }
+    if (merchants.length > 1) {
+      return { paymentType: PaymentType.Merchant, merchants }
+    }
+  }
+
   const paymentType = getPaymentType({
     protocol,
     destinationWithoutProtocol,
     rawDestination: destination,
-    network,
   })
   switch (paymentType) {
     case PaymentType.Lnurl:

--- a/src/parsing/merchants.spec.ts
+++ b/src/parsing/merchants.spec.ts
@@ -1,6 +1,7 @@
 import type { Network } from "./types"
 import {
   convertMerchantQRToLightningAddress,
+  getMatchingMerchants,
   merchants,
   strictUriEncode,
 } from "./merchants"
@@ -247,6 +248,37 @@ describe("convertMerchantQRToLightningAddress", () => {
   })
 })
 
+describe("getMatchingMerchants", () => {
+  test("returns public metadata and a network-specific lnurl", () => {
+    expect(
+      getMatchingMerchants({
+        qrContent: "CRSTPC-12-345-6789-10-11",
+        network: "signet",
+      }),
+    ).toEqual([
+      {
+        id: "servest-parking",
+        lnurl: "CRSTPC-12-345-6789-10-11@staging.cryptoqr.net",
+        category: "merchant-payment",
+        title: "Servest Parking",
+        description: "",
+        companyName: "Money Badger",
+        termsUrl: "https://www.moneybadger.co.za/deals/terms-and-conditions",
+        displayCurrency: "ZAR",
+      },
+    ])
+  })
+
+  test("returns all matches in configuration order", () => {
+    const qrContent =
+      "00020129530023za.co.electrum.picknpay.za.co.ecentric0122RD2HAK3KTI53EC/confirm"
+
+    expect(
+      getMatchingMerchants({ qrContent, network: "mainnet" }).map(({ id }) => id),
+    ).toEqual(["picknpay", "ecentric"])
+  })
+})
+
 describe("convertMerchantQRToLightningAddress with displayCurrency", () => {
   const originalMerchants = [...merchants]
 
@@ -255,6 +287,11 @@ describe("convertMerchantQRToLightningAddress with displayCurrency", () => {
     merchants.push(
       {
         id: "test-usd",
+        category: "merchant-payment",
+        title: "Test Usd",
+        description: "",
+        companyName: "Money Badger",
+        termsUrl: "https://www.moneybadger.co.za/deals/terms-and-conditions",
         identifierRegex: /(?<identifier>.*test-payment.*)/iu,
         defaultDomain: "usd-merchant.com",
         domains: {
@@ -266,6 +303,11 @@ describe("convertMerchantQRToLightningAddress with displayCurrency", () => {
       },
       {
         id: "test-zar",
+        category: "merchant-payment",
+        title: "Test Zar",
+        description: "",
+        companyName: "Money Badger",
+        termsUrl: "https://www.moneybadger.co.za/deals/terms-and-conditions",
         identifierRegex: /(?<identifier>.*test-payment.*)/iu,
         defaultDomain: "zar-merchant.com",
         domains: {
@@ -336,6 +378,11 @@ describe("convertMerchantQRToLightningAddress with displayCurrency", () => {
     merchants.length = 0
     merchants.push({
       id: "test-single",
+      category: "merchant-payment",
+      title: "Test Single",
+      description: "",
+      companyName: "Money Badger",
+      termsUrl: "https://www.moneybadger.co.za/deals/terms-and-conditions",
       identifierRegex: /(?<identifier>.*test-payment.*)/iu,
       defaultDomain: "single-merchant.com",
       domains: {
@@ -352,6 +399,33 @@ describe("convertMerchantQRToLightningAddress with displayCurrency", () => {
     })
 
     expect(result).toBe("test-payment-qr@single-merchant.com")
+  })
+
+  test("returns null when multiple merchants match the requested currency", () => {
+    merchants.push({
+      id: "test-zar-duplicate",
+      category: "merchant-payment",
+      title: "Test Zar Duplicate",
+      description: "",
+      companyName: "Money Badger",
+      termsUrl: "https://www.moneybadger.co.za/deals/terms-and-conditions",
+      identifierRegex: /(?<identifier>.*test-payment.*)/iu,
+      defaultDomain: "zar-duplicate-merchant.com",
+      domains: {
+        mainnet: "zar-duplicate-merchant.com",
+        signet: "staging.zar-duplicate-merchant.com",
+        regtest: "staging.zar-duplicate-merchant.com",
+      },
+      displayCurrency: "ZAR",
+    })
+
+    expect(
+      convertMerchantQRToLightningAddress({
+        qrContent: "test-payment-qr",
+        network: "mainnet",
+        displayCurrency: "ZAR",
+      }),
+    ).toBeNull()
   })
 })
 

--- a/src/parsing/merchants.spec.ts
+++ b/src/parsing/merchants.spec.ts
@@ -261,7 +261,7 @@ describe("getMatchingMerchants", () => {
         lnurl: "CRSTPC-12-345-6789-10-11@staging.cryptoqr.net",
         category: "merchant-payment",
         title: "Servest Parking",
-        description: "",
+        description: "Money Badger merchant",
         companyName: "Money Badger",
         termsUrl: "https://www.moneybadger.co.za/deals/terms-and-conditions",
         displayCurrency: "ZAR",

--- a/src/parsing/merchants.ts
+++ b/src/parsing/merchants.ts
@@ -22,7 +22,7 @@ type MerchantConfig = Omit<Merchant, "lnurl"> & {
 const moneyBadgerTermsUrl = "https://www.moneybadger.co.za/deals/terms-and-conditions"
 const moneyBadgerMerchant = {
   category: "merchant-payment",
-  description: "",
+  description: "Money Badger merchant",
   companyName: "Money Badger",
   termsUrl: moneyBadgerTermsUrl,
 } satisfies Pick<Merchant, "category" | "description" | "companyName" | "termsUrl">

--- a/src/parsing/merchants.ts
+++ b/src/parsing/merchants.ts
@@ -1,16 +1,37 @@
 import type { Network } from "./types.ts"
 
-type MerchantConfig = {
+export type MerchantCategory = "merchant-payment" | "swap"
+
+export type Merchant = {
   id: string
+  lnurl: string
+  category: MerchantCategory
+  title: string
+  description: string
+  companyName: string
+  termsUrl: string
+  displayCurrency?: string
+}
+
+type MerchantConfig = Omit<Merchant, "lnurl"> & {
   identifierRegex: RegExp
   defaultDomain: string
   domains: { [K in Network]: string }
-  displayCurrency?: string
 }
+
+const moneyBadgerTermsUrl = "https://www.moneybadger.co.za/deals/terms-and-conditions"
+const moneyBadgerMerchant = {
+  category: "merchant-payment",
+  description: "",
+  companyName: "Money Badger",
+  termsUrl: moneyBadgerTermsUrl,
+} satisfies Pick<Merchant, "category" | "description" | "companyName" | "termsUrl">
 
 export const merchants: MerchantConfig[] = [
   {
     id: "picknpay",
+    title: "Pick n Pay",
+    ...moneyBadgerMerchant,
     displayCurrency: "ZAR",
     identifierRegex: /(?<identifier>.*za\.co\.electrum\.picknpay.*)/iu,
     defaultDomain: "cryptoqr.net",
@@ -22,6 +43,8 @@ export const merchants: MerchantConfig[] = [
   },
   {
     id: "ecentric",
+    title: "Ecentric",
+    ...moneyBadgerMerchant,
     displayCurrency: "ZAR",
     identifierRegex: /(?<identifier>.*za\.co\.ecentric.*)/iu,
     defaultDomain: "cryptoqr.net",
@@ -33,6 +56,8 @@ export const merchants: MerchantConfig[] = [
   },
   {
     id: "yoyo",
+    title: "Yoyo",
+    ...moneyBadgerMerchant,
     displayCurrency: "ZAR",
     identifierRegex: /(?<identifier>.*(wigroup\.co|yoyogroup\.co).*)/iu,
     defaultDomain: "cryptoqr.net",
@@ -44,6 +69,8 @@ export const merchants: MerchantConfig[] = [
   },
   {
     id: "zapper",
+    title: "Zapper",
+    ...moneyBadgerMerchant,
     displayCurrency: "ZAR",
     identifierRegex: /(?<identifier>.*(zapper\.com|\d+\.zap\.pe).*)/iu,
     defaultDomain: "cryptoqr.net",
@@ -55,6 +82,8 @@ export const merchants: MerchantConfig[] = [
   },
   {
     id: "payat",
+    title: "Payat",
+    ...moneyBadgerMerchant,
     displayCurrency: "ZAR",
     identifierRegex: /(?<identifier>.*payat\.io.*)/iu,
     defaultDomain: "cryptoqr.net",
@@ -66,6 +95,8 @@ export const merchants: MerchantConfig[] = [
   },
   {
     id: "paynow-netcash",
+    title: "Paynow Netcash",
+    ...moneyBadgerMerchant,
     displayCurrency: "ZAR",
     identifierRegex: /(?<identifier>.*paynow\.netcash\.co\.za.*)/iu,
     defaultDomain: "cryptoqr.net",
@@ -77,6 +108,8 @@ export const merchants: MerchantConfig[] = [
   },
   {
     id: "paynow-sagepay",
+    title: "Paynow Sagepay",
+    ...moneyBadgerMerchant,
     displayCurrency: "ZAR",
     identifierRegex: /(?<identifier>.*paynow\.sagepay\.co\.za.*)/iu,
     defaultDomain: "cryptoqr.net",
@@ -88,6 +121,8 @@ export const merchants: MerchantConfig[] = [
   },
   {
     id: "standard-bank-scantopay",
+    title: "Standard Bank Scantopay",
+    ...moneyBadgerMerchant,
     displayCurrency: "ZAR",
     identifierRegex: /(?<identifier>SK-\d{1,}-\d{23})/iu,
     defaultDomain: "cryptoqr.net",
@@ -99,6 +134,8 @@ export const merchants: MerchantConfig[] = [
   },
   {
     id: "transactionjunction",
+    title: "Transaction Junction",
+    ...moneyBadgerMerchant,
     displayCurrency: "ZAR",
     identifierRegex: /(?<identifier>.*transactionjunction\.co\.za.*)/iu,
     defaultDomain: "cryptoqr.net",
@@ -110,6 +147,8 @@ export const merchants: MerchantConfig[] = [
   },
   {
     id: "servest-parking",
+    title: "Servest Parking",
+    ...moneyBadgerMerchant,
     displayCurrency: "ZAR",
     identifierRegex: /(?<identifier>CRSTPC-\d+-\d+-\d+-\d+-\d+)/iu,
     defaultDomain: "cryptoqr.net",
@@ -121,6 +160,8 @@ export const merchants: MerchantConfig[] = [
   },
   {
     id: "payat-generic",
+    title: "Payat",
+    ...moneyBadgerMerchant,
     displayCurrency: "ZAR",
     identifierRegex: /(?<identifier>.{2}\/.{4}\/.{20})/iu,
     defaultDomain: "cryptoqr.net",
@@ -132,6 +173,8 @@ export const merchants: MerchantConfig[] = [
   },
   {
     id: "scantopay-url",
+    title: "Scantopay Url",
+    ...moneyBadgerMerchant,
     displayCurrency: "ZAR",
     identifierRegex: /(?<identifier>.*(scantopay\.io).*)/iu,
     defaultDomain: "cryptoqr.net",
@@ -143,6 +186,8 @@ export const merchants: MerchantConfig[] = [
   },
   {
     id: "scantopay-10-digits",
+    title: "Scantopay 10 Digits",
+    ...moneyBadgerMerchant,
     displayCurrency: "ZAR",
     identifierRegex: /^(?<identifier>\d{10})$/iu,
     defaultDomain: "cryptoqr.net",
@@ -154,6 +199,8 @@ export const merchants: MerchantConfig[] = [
   },
   {
     id: "snapscan",
+    title: "Snapscan",
+    ...moneyBadgerMerchant,
     displayCurrency: "ZAR",
     identifierRegex: /(?<identifier>.*(snapscan).*)/iu,
     defaultDomain: "cryptoqr.net",
@@ -173,6 +220,62 @@ export const strictUriEncode = (uriComponent: string | number | boolean): string
   )
 }
 
+export const getMatchingMerchants = ({
+  qrContent,
+  network,
+}: {
+  qrContent: string
+  network: Network
+}): Merchant[] => {
+  if (!qrContent) {
+    return []
+  }
+
+  return merchants.reduce<Merchant[]>((matchedMerchants, merchant) => {
+    const match = qrContent.match(merchant.identifierRegex)
+    const identifier = match?.groups?.identifier
+    if (!identifier) {
+      return matchedMerchants
+    }
+
+    const domain = merchant.domains[network] || merchant.defaultDomain
+    matchedMerchants.push({
+      id: merchant.id,
+      lnurl: `${strictUriEncode(identifier)}@${domain}`,
+      category: merchant.category,
+      title: merchant.title,
+      description: merchant.description,
+      companyName: merchant.companyName,
+      termsUrl: merchant.termsUrl,
+      displayCurrency: merchant.displayCurrency,
+    })
+    return matchedMerchants
+  }, [])
+}
+
+export const getCurrencyMatchedMerchant = ({
+  merchants: matchingMerchants,
+  displayCurrency,
+}: {
+  merchants: Merchant[]
+  displayCurrency?: string
+}): Merchant | null => {
+  if (matchingMerchants.length === 1) {
+    return matchingMerchants[0]
+  }
+
+  const normalizedCurrency = displayCurrency?.trim().toUpperCase()
+  if (!normalizedCurrency) {
+    return null
+  }
+
+  const currencyMatches = matchingMerchants.filter(
+    (merchant) => merchant.displayCurrency?.toUpperCase() === normalizedCurrency,
+  )
+
+  return currencyMatches.length === 1 ? currencyMatches[0] : null
+}
+
 export const convertMerchantQRToLightningAddress = ({
   qrContent,
   network,
@@ -182,42 +285,10 @@ export const convertMerchantQRToLightningAddress = ({
   network: Network
   displayCurrency?: string
 }): string | null => {
-  if (!qrContent) {
-    return null
-  }
+  const merchant = getCurrencyMatchedMerchant({
+    merchants: getMatchingMerchants({ qrContent, network }),
+    displayCurrency,
+  })
 
-  const matchedMerchants = merchants.reduce<
-    Array<{ lnurl: string; displayCurrency?: string }>
-  >((acc, merchant) => {
-    const match = qrContent.match(merchant.identifierRegex)
-    if (match?.groups?.identifier) {
-      const domain = merchant.domains[network] || merchant.defaultDomain
-      acc.push({
-        lnurl: `${strictUriEncode(match.groups.identifier)}@${domain}`,
-        displayCurrency: merchant.displayCurrency,
-      })
-    }
-    return acc
-  }, [])
-
-  if (matchedMerchants.length === 0) {
-    return null
-  }
-
-  if (matchedMerchants.length === 1) {
-    return matchedMerchants[0].lnurl
-  }
-
-  const normalizedCurrency = displayCurrency?.trim().toUpperCase()
-  const currencyMatch = normalizedCurrency
-    ? matchedMerchants.find(
-        (merchant) => merchant.displayCurrency?.toUpperCase() === normalizedCurrency,
-      )
-    : undefined
-
-  if (currencyMatch) {
-    return currencyMatch.lnurl
-  }
-
-  return null
+  return merchant?.lnurl ?? null
 }


### PR DESCRIPTION
Adds `PaymentType.Merchant` for payment inputs matching multiple merchant providers. Single and currency-disambiguated matches continue returning LNURL results with additive `merchant` metadata. QR scans retain merchant-over-phone priority, while manually entered phone numbers remain phone LNURLs.