### PR TITLE
feat: configure phone lightning address domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,23 @@ import { parsePaymentDestination } from "@blinkbitcoin/blink-client"
 const { valid, paymentType, amount } = parsePaymentDestination({
   destination: "username or invoice or bitcoin address",
   network: "mainnet", // or signet or regtest
+  lnAddressDomains: ["blink.sv"],
 })
+```
+
+Valid phone number inputs resolve as Lightning Addresses using `pay.blink.sv` on
+mainnet and `pay.staging.blink.sv` on signet or regtest. Set
+`phoneNumberLnAddressDomain` to override only the phone number Lightning Address
+domain:
+
+```js
+parsePaymentDestination({
+  destination: "+50370123456",
+  network: "mainnet",
+  lnAddressDomains: ["blink.sv"],
+  phoneNumberLnAddressDomain: "phone.example.com",
+})
+// lnurl: "+50370123456@phone.example.com"
 ```
 
 When a QR code or non-phone manual input matches one merchant payment integration, the

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Galoy Client
+# Blink Client
 
 JavaScript client library for the Blink stack. This is used in front-end applications like the web and mobile wallets.
 
@@ -7,7 +7,7 @@ JavaScript client library for the Blink stack. This is used in front-end applica
 Install the package with:
 
 ```bash
-yarn add @blinkbitcoin/blink-client
+pnpm add @blinkbitcoin/blink-client
 ```
 
 ## Usage
@@ -103,53 +103,26 @@ pnpm unlink --global
 </details>
 
 <details>
-<summary>using yarn</summary>
-
-Run:
-
-```bash
-yarn link
-```
-
-and in your test project run:
-
-```bash
-yarn link @galoymoney/client
-```
-
-If you want to remove the symlink, run:
-
-```bash
-# in your test project
-yarn unlink @galoymoney/client
-
-# in galoymoney/client folder
-yarn unlink
-```
-
-</details>
-
-<details>
 <summary>using yalc</summary>
 
 Run:
 
 ```bash
-# in galoymoney/client folder
+# in blinkbitcoin/blink-client folder
 yalc publish
 ```
 
 in your test project run:
 
 ```bash
-yalc add @galoymoney/client
+yalc add @blinkbitcoin/blink-client
 ```
 
 If you want to remove the symlink, run:
 
 ```bash
 # in your test project
-yalc remove @galoymoney/client
+yalc remove @blinkbitcoin/blink-client
 ```
 
 to update changes, you have to run <code>yalc publish</code> before run:

--- a/README.md
+++ b/README.md
@@ -24,10 +24,9 @@ const { valid, paymentType, amount } = parsePaymentDestination({
 })
 ```
 
-Valid phone number inputs resolve as Lightning Addresses using `pay.blink.sv` on
-mainnet and `pay.staging.blink.sv` on signet or regtest. Set
-`phoneNumberLnAddressDomain` to override only the phone number Lightning Address
-domain:
+Valid phone number inputs resolve as Lightning Addresses on `pay.blink.sv` for
+mainnet and `pay.staging.blink.sv` for signet or regtest. Set
+`phoneNumberLnAddressDomain` to override only that phone-number domain:
 
 ```js
 parsePaymentDestination({

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,22 +3,24 @@ import { parsePaymentDestination } from "./parsing/index"
 const args = process.argv.slice(2)
 
 if (args.length < 1) {
-  console.error("Usage: pnpm cli <destination> [network] [lnAddressDomains]")
   console.error(
-    "Example: pnpm cli lnbc1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpl2pkx2ctnv5sxxmmwwd5kgetjypeh2ursdae8g6twvus8g6rfwvs8qun0dfjkxaq mainnet blink.sv",
+    "Usage: pnpm cli <destination> [network] [lnAddressDomains] [phoneNumberLnAddressDomain]",
   )
+  console.error("Example: pnpm cli +50370123456 mainnet blink.sv phone.example.com")
   process.exit(1)
 }
 
 const destination = args[0]
 const network = args[1] || "mainnet" // Default to mainnet if not specified
 const lnAddressDomains = args[2] ? args[2].split(",") : [] // Default to empty array if not specified
+const phoneNumberLnAddressDomain = args[3]
 
 try {
   const result = parsePaymentDestination({
     destination,
     network: network as "mainnet" | "signet" | "regtest",
     lnAddressDomains,
+    phoneNumberLnAddressDomain,
   })
 
   console.info(JSON.stringify(result, null, 2))

--- a/src/parsing/index.spec.ts
+++ b/src/parsing/index.spec.ts
@@ -1122,6 +1122,23 @@ describe("parsePaymentDestination - Phone Number as LNURL Payment", () => {
       }),
     )
   })
+
+  it("keeps phone number lightning addresses as lnurls on internal domains", () => {
+    const paymentDestination = parsePaymentDestination({
+      destination: "+50370123456@pay.blink.sv",
+      network: "mainnet",
+      lnAddressDomains: ["blink.sv", "pay.blink.sv"],
+    })
+
+    expect(paymentDestination).toEqual(
+      expect.objectContaining({
+        paymentType: PaymentType.Lnurl,
+        lnurl: "+50370123456@pay.blink.sv",
+        valid: true,
+        isMerchant: false,
+      }),
+    )
+  })
 })
 
 describe("parsePaymentDestination Merchant QR", () => {

--- a/src/parsing/index.spec.ts
+++ b/src/parsing/index.spec.ts
@@ -954,7 +954,7 @@ describe("parsePaymentDestination with preferLnurlForInternalHandles", () => {
       expect.objectContaining({
         paymentType: PaymentType.Lnurl,
         valid: true,
-        lnurl: `+50370123456@${lnAddressDomains[0]}`,
+        lnurl: "+50370123456@pay.blink.sv",
         isMerchant: false,
       }),
     )
@@ -964,6 +964,9 @@ describe("parsePaymentDestination with preferLnurlForInternalHandles", () => {
 describe("parsePaymentDestination - Phone Number as LNURL Payment", () => {
   const networks: Network[] = ["mainnet", "signet", "regtest"]
   const lnAddressDomains = ["blink.sv"]
+  const getPhoneNumberLnAddressDomain = (network: Network) => {
+    return network === "mainnet" ? "pay.blink.sv" : "pay.staging.blink.sv"
+  }
 
   test.each(
     networks.flatMap((network) => [
@@ -973,7 +976,7 @@ describe("parsePaymentDestination - Phone Number as LNURL Payment", () => {
         network,
         expected: {
           paymentType: PaymentType.Lnurl,
-          lnurl: `+50370123456@${lnAddressDomains[0]}`,
+          lnurl: `+50370123456@${getPhoneNumberLnAddressDomain(network)}`,
           valid: true,
           isMerchant: false,
         },
@@ -984,7 +987,7 @@ describe("parsePaymentDestination - Phone Number as LNURL Payment", () => {
         network,
         expected: {
           paymentType: PaymentType.Lnurl,
-          lnurl: `50370123456@${lnAddressDomains[0]}`,
+          lnurl: `50370123456@${getPhoneNumberLnAddressDomain(network)}`,
           valid: true,
           isMerchant: false,
         },
@@ -995,7 +998,7 @@ describe("parsePaymentDestination - Phone Number as LNURL Payment", () => {
         network,
         expected: {
           paymentType: PaymentType.Lnurl,
-          lnurl: `0050370123456@${lnAddressDomains[0]}`,
+          lnurl: `0050370123456@${getPhoneNumberLnAddressDomain(network)}`,
           valid: true,
           isMerchant: false,
         },
@@ -1006,7 +1009,7 @@ describe("parsePaymentDestination - Phone Number as LNURL Payment", () => {
         network,
         expected: {
           paymentType: PaymentType.Lnurl,
-          lnurl: `00 503 7012 3456@${lnAddressDomains[0]}`,
+          lnurl: `00 503 7012 3456@${getPhoneNumberLnAddressDomain(network)}`,
           valid: true,
           isMerchant: false,
         },
@@ -1017,7 +1020,7 @@ describe("parsePaymentDestination - Phone Number as LNURL Payment", () => {
         network,
         expected: {
           paymentType: PaymentType.Lnurl,
-          lnurl: `+12025550123@${lnAddressDomains[0]}`,
+          lnurl: `+12025550123@${getPhoneNumberLnAddressDomain(network)}`,
           valid: true,
           isMerchant: false,
         },
@@ -1028,7 +1031,7 @@ describe("parsePaymentDestination - Phone Number as LNURL Payment", () => {
         network,
         expected: {
           paymentType: PaymentType.Lnurl,
-          lnurl: `0012025550123@${lnAddressDomains[0]}`,
+          lnurl: `0012025550123@${getPhoneNumberLnAddressDomain(network)}`,
           valid: true,
           isMerchant: false,
         },
@@ -1078,6 +1081,44 @@ describe("parsePaymentDestination - Phone Number as LNURL Payment", () => {
     })
 
     expect(paymentDestination).toEqual(expect.objectContaining(expected))
+  })
+
+  test.each(networks)(
+    "uses a custom phone number lightning address domain on %s",
+    (network) => {
+      const paymentDestination = parsePaymentDestination({
+        destination: "+50370123456",
+        network,
+        lnAddressDomains,
+        phoneNumberLnAddressDomain: "phone.example.com",
+      })
+
+      expect(paymentDestination).toEqual(
+        expect.objectContaining({
+          paymentType: PaymentType.Lnurl,
+          lnurl: "+50370123456@phone.example.com",
+          valid: true,
+          isMerchant: false,
+        }),
+      )
+    },
+  )
+
+  it("does not use lnAddressDomains for phone number lnurls", () => {
+    const paymentDestination = parsePaymentDestination({
+      destination: "+50370123456",
+      network: "mainnet",
+      lnAddressDomains: ["internal.example.com"],
+    })
+
+    expect(paymentDestination).toEqual(
+      expect.objectContaining({
+        paymentType: PaymentType.Lnurl,
+        lnurl: "+50370123456@pay.blink.sv",
+        valid: true,
+        isMerchant: false,
+      }),
+    )
   })
 })
 
@@ -1504,7 +1545,7 @@ describe("parsePaymentDestination QR Input with Merchant Priority", () => {
       expect.objectContaining({
         paymentType: PaymentType.Lnurl,
         valid: true,
-        lnurl: `${phoneNumber}@blink.sv`,
+        lnurl: `${phoneNumber}@pay.blink.sv`,
         isMerchant: false,
       }),
     )
@@ -1526,7 +1567,7 @@ describe("parsePaymentDestination QR Input with Merchant Priority", () => {
       expect.objectContaining({
         paymentType: PaymentType.Lnurl,
         valid: true,
-        lnurl: `${phoneNumber}@blink.sv`,
+        lnurl: `${phoneNumber}@pay.blink.sv`,
         isMerchant: false,
       }),
     )
@@ -1546,7 +1587,7 @@ describe("parsePaymentDestination QR Input with Merchant Priority", () => {
       expect.objectContaining({
         paymentType: PaymentType.Lnurl,
         valid: true,
-        lnurl: `${phoneNumber}@blink.sv`,
+        lnurl: `${phoneNumber}@pay.blink.sv`,
         isMerchant: false,
       }),
     )

--- a/src/parsing/index.spec.ts
+++ b/src/parsing/index.spec.ts
@@ -964,8 +964,10 @@ describe("parsePaymentDestination with preferLnurlForInternalHandles", () => {
 describe("parsePaymentDestination - Phone Number as LNURL Payment", () => {
   const networks: Network[] = ["mainnet", "signet", "regtest"]
   const lnAddressDomains = ["blink.sv"]
-  const getPhoneNumberLnAddressDomain = (network: Network) => {
-    return network === "mainnet" ? "pay.blink.sv" : "pay.staging.blink.sv"
+  const defaultPhoneLnAddressDomain: Record<Network, string> = {
+    mainnet: "pay.blink.sv",
+    signet: "pay.staging.blink.sv",
+    regtest: "pay.staging.blink.sv",
   }
 
   test.each(
@@ -976,7 +978,7 @@ describe("parsePaymentDestination - Phone Number as LNURL Payment", () => {
         network,
         expected: {
           paymentType: PaymentType.Lnurl,
-          lnurl: `+50370123456@${getPhoneNumberLnAddressDomain(network)}`,
+          lnurl: `+50370123456@${defaultPhoneLnAddressDomain[network]}`,
           valid: true,
           isMerchant: false,
         },
@@ -987,7 +989,7 @@ describe("parsePaymentDestination - Phone Number as LNURL Payment", () => {
         network,
         expected: {
           paymentType: PaymentType.Lnurl,
-          lnurl: `50370123456@${getPhoneNumberLnAddressDomain(network)}`,
+          lnurl: `50370123456@${defaultPhoneLnAddressDomain[network]}`,
           valid: true,
           isMerchant: false,
         },
@@ -998,7 +1000,7 @@ describe("parsePaymentDestination - Phone Number as LNURL Payment", () => {
         network,
         expected: {
           paymentType: PaymentType.Lnurl,
-          lnurl: `0050370123456@${getPhoneNumberLnAddressDomain(network)}`,
+          lnurl: `0050370123456@${defaultPhoneLnAddressDomain[network]}`,
           valid: true,
           isMerchant: false,
         },
@@ -1009,7 +1011,7 @@ describe("parsePaymentDestination - Phone Number as LNURL Payment", () => {
         network,
         expected: {
           paymentType: PaymentType.Lnurl,
-          lnurl: `00 503 7012 3456@${getPhoneNumberLnAddressDomain(network)}`,
+          lnurl: `00 503 7012 3456@${defaultPhoneLnAddressDomain[network]}`,
           valid: true,
           isMerchant: false,
         },
@@ -1020,7 +1022,7 @@ describe("parsePaymentDestination - Phone Number as LNURL Payment", () => {
         network,
         expected: {
           paymentType: PaymentType.Lnurl,
-          lnurl: `+12025550123@${getPhoneNumberLnAddressDomain(network)}`,
+          lnurl: `+12025550123@${defaultPhoneLnAddressDomain[network]}`,
           valid: true,
           isMerchant: false,
         },
@@ -1031,7 +1033,7 @@ describe("parsePaymentDestination - Phone Number as LNURL Payment", () => {
         network,
         expected: {
           paymentType: PaymentType.Lnurl,
-          lnurl: `0012025550123@${getPhoneNumberLnAddressDomain(network)}`,
+          lnurl: `0012025550123@${defaultPhoneLnAddressDomain[network]}`,
           valid: true,
           isMerchant: false,
         },

--- a/src/parsing/index.spec.ts
+++ b/src/parsing/index.spec.ts
@@ -1409,6 +1409,22 @@ describe("parsePaymentDestination - Numeric Lightning Addresses", () => {
     expect(result).not.toHaveProperty("merchant")
   })
 
+  it("validates an external lightning address with leading zero numeric username", () => {
+    const result = parsePaymentDestination({
+      destination: "0777491011@example.com",
+      network: "mainnet",
+      lnAddressDomains: ["blink.sv", "pay.blink.sv"],
+    })
+    expect(result).toEqual(
+      expect.objectContaining({
+        paymentType: PaymentType.Lnurl,
+        valid: true,
+        lnurl: "0777491011@example.com",
+        isMerchant: false,
+      }),
+    )
+  })
+
   it("validates an external lightning address with phone number username (with +)", () => {
     const result = parsePaymentDestination({
       destination: "+254793673300@bitcoin.co.ke",

--- a/src/parsing/index.ts
+++ b/src/parsing/index.ts
@@ -508,6 +508,15 @@ const getLNURLPayResponse = ({
     const resolveAsLnurl =
       preferLnurlForInternalHandles && Boolean(username.match(reUsername))
 
+    if (domain === phoneNumberLnAddressDomain && isValidPhoneNumber(username)) {
+      return {
+        valid: true,
+        paymentType: PaymentType.Lnurl,
+        lnurl: `${username}@${domain}`,
+        isMerchant: false,
+      }
+    }
+
     if (!resolveAsLnurl && lnAddressDomains.includes(domain)) {
       return getIntraLedgerPayResponse({
         destinationWithoutProtocol: username,

--- a/src/parsing/index.ts
+++ b/src/parsing/index.ts
@@ -281,9 +281,14 @@ type ParsePaymentDestinationArgs = {
   destination: string
   network: Network
   lnAddressDomains: string[]
+  phoneNumberLnAddressDomain?: string
   inputSource?: InputSource
   displayCurrency?: string
   preferLnurlForInternalHandles?: boolean
+}
+
+const getDefaultPhoneNumberLnAddressDomain = (network: Network): string => {
+  return network === "mainnet" ? "pay.blink.sv" : "pay.staging.blink.sv"
 }
 
 const getLNParam = (data: string): string | null => {
@@ -482,10 +487,12 @@ const getMerchantLnurlPaymentDestination = ({
 
 const getLNURLPayResponse = ({
   lnAddressDomains,
+  phoneNumberLnAddressDomain,
   destination,
   preferLnurlForInternalHandles = false,
 }: {
   lnAddressDomains: string[]
+  phoneNumberLnAddressDomain: string
   destination: string
   preferLnurlForInternalHandles?: boolean
 }):
@@ -518,11 +525,10 @@ const getLNURLPayResponse = ({
   }
 
   if (isValidPhoneNumber(trimmed)) {
-    const domain = lnAddressDomains[0]
     return {
       valid: true,
       paymentType: PaymentType.Lnurl,
-      lnurl: `${trimmed}@${domain}`,
+      lnurl: `${trimmed}@${phoneNumberLnAddressDomain}`,
       isMerchant: false,
     }
   }
@@ -698,6 +704,7 @@ export const parsePaymentDestination = ({
   destination,
   network,
   lnAddressDomains,
+  phoneNumberLnAddressDomain,
   inputSource = "manual",
   displayCurrency,
   preferLnurlForInternalHandles = false,
@@ -748,6 +755,8 @@ export const parsePaymentDestination = ({
     case PaymentType.Lnurl:
       return getLNURLPayResponse({
         lnAddressDomains,
+        phoneNumberLnAddressDomain:
+          phoneNumberLnAddressDomain ?? getDefaultPhoneNumberLnAddressDomain(network),
         destination: destinationForParsing,
         preferLnurlForInternalHandles,
       })

--- a/src/parsing/index.ts
+++ b/src/parsing/index.ts
@@ -751,12 +751,14 @@ export const parsePaymentDestination = ({
     }
   }
 
+  const phoneDomain =
+    phoneNumberLnAddressDomain ?? getDefaultPhoneNumberLnAddressDomain(network)
+
   switch (paymentType) {
     case PaymentType.Lnurl:
       return getLNURLPayResponse({
         lnAddressDomains,
-        phoneNumberLnAddressDomain:
-          phoneNumberLnAddressDomain ?? getDefaultPhoneNumberLnAddressDomain(network),
+        phoneNumberLnAddressDomain: phoneDomain,
         destination: destinationForParsing,
         preferLnurlForInternalHandles,
       })


### PR DESCRIPTION
## Summary
- Add a dedicated phone number Lightning Address domain option
- Default phone number domains to pay.blink.sv on mainnet and pay.staging.blink.sv on signet/regtest
- Keep internal Lightning Address domains separate from phone number domains