### PR TITLE
fix: resolve single swap merchant as lnurl

### DIFF
--- a/src/parsing/index.spec.ts
+++ b/src/parsing/index.spec.ts
@@ -1319,21 +1319,21 @@ describe("parsePaymentDestination Merchant QR", () => {
   })
 
   it("returns one merchant choice for one filtered swap route", () => {
-    const result = parsePaymentDestination({
-      destination: `${evmRecipient}+USDC+Arbitrum`,
-      network: "mainnet",
-      lnAddressDomains: ["blink.sv"],
-    })
-
-    expect(result).toEqual({
-      paymentType: PaymentType.Merchant,
-      merchants: [
-        expect.objectContaining({
-          id: "blink-boltz-usdc-arbitrum",
-          lnurl: `${evmRecipient}+USDC+Arbitrum@swap.blink.sv`,
-        }),
-      ],
-    })
+    expect(
+      parsePaymentDestination({
+        destination: `${evmRecipient}+USDC+Arbitrum`,
+        network: "mainnet",
+        lnAddressDomains: ["blink.sv"],
+      }),
+    ).toEqual(
+      expect.objectContaining({
+        paymentType: PaymentType.Lnurl,
+        valid: true,
+        lnurl: `${evmRecipient}+USDC+Arbitrum@swap.blink.sv`,
+        isMerchant: true,
+        merchant: expect.objectContaining({ id: "blink-boltz-usdc-arbitrum" }),
+      }),
+    )
   })
 
   it("returns only compatible stablecoin swap choices for non-EVM recipients", () => {
@@ -1364,10 +1364,11 @@ describe("parsePaymentDestination Merchant QR", () => {
       }),
     ).toEqual(
       expect.objectContaining({
-        paymentType: PaymentType.Merchant,
-        merchants: [
-          expect.objectContaining({ lnurl: `${tronRecipient}+USDT+Tron@swap.blink.sv` }),
-        ],
+        paymentType: PaymentType.Lnurl,
+        valid: true,
+        lnurl: `${tronRecipient}+USDT+Tron@swap.blink.sv`,
+        isMerchant: true,
+        merchant: expect.objectContaining({ id: "blink-boltz-usdt-tron" }),
       }),
     )
   })

--- a/src/parsing/merchants/index.ts
+++ b/src/parsing/merchants/index.ts
@@ -61,7 +61,7 @@ export const getCurrencyMatchedMerchant = ({
   displayCurrency?: string
 }): Merchant | null => {
   if (matchingMerchants.length === 1) {
-    return matchingMerchants[0].category === "swap" ? null : matchingMerchants[0]
+    return matchingMerchants[0]
   }
 
   const normalizedCurrency = displayCurrency?.trim().toUpperCase()


### PR DESCRIPTION
## Summary
- resolve unambiguous single merchant matches as Lnurl results, including swap merchants
- update swap parser expectations for single-route EVM and Tron swaps